### PR TITLE
Reinstalled libharfbuzz0b to resolve "undefined symbol: FcWeightFromOpenTypeDouble error."

### DIFF
--- a/Release/ARM-32/XFCE.sh
+++ b/Release/ARM-32/XFCE.sh
@@ -1,4 +1,5 @@
 echo $0 $*
+apt install --reinstall libharfbuzz0b -y
 progdir=`dirname "$0"`
 log=$progdir/XFCE.log
 rm /var/log/Xorg*

--- a/Release/ARM-64/XFCE.sh
+++ b/Release/ARM-64/XFCE.sh
@@ -1,4 +1,5 @@
 echo $0 $*
+apt install --reinstall libharfbuzz0b -y
 progdir=`dirname "$0"`
 log=$progdir/XFCE.log
 rm /var/log/Xorg*


### PR DESCRIPTION
xfce4-session: symbol lookup error: /lib/aarch64-linux-gnu/libpangoft2-1.0.so.0: undefined symbol: FcWeightFromOpenTypeDouble

issue resolved in the latest stock OS.